### PR TITLE
(main) PORT-27773 BLEM: Update PHP to version 8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,29 +32,29 @@ RUN apt-get install -y \
 RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
 
 # PHP
-RUN LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && apt-get update && apt-get install -y php8.2
+RUN LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && apt-get update && apt-get install -y php8.4
 RUN apt-get install -y \
-    php8.2-cli \
-    php8.2-fpm \
-    php8.2-curl \
-    php8.2-gd \
-    php8.2-dev \
-    php8.2-xml \
-    php8.2-bcmath \
-    php8.2-mysql \
-    php8.2-pgsql \
-    php8.2-zip \
-    php8.2-bz2 \
-    php8.2-sqlite \
-    php8.2-soap \
-    php8.2-intl \
-    php8.2-imap \
-    php8.2-imagick \
-    php8.2-amqp \
-    php8.2-xml \
-    php8.2-mbstring \
-    php8.2-memcached \
-    php8.2-opentelemetry
+    php8.4-cli \
+    php8.4-fpm \
+    php8.4-curl \
+    php8.4-gd \
+    php8.4-dev \
+    php8.4-xml \
+    php8.4-bcmath \
+    php8.4-mysql \
+    php8.4-pgsql \
+    php8.4-zip \
+    php8.4-bz2 \
+    php8.4-sqlite \
+    php8.4-soap \
+    php8.4-intl \
+    php8.4-imap \
+    php8.4-imagick \
+    php8.4-amqp \
+    php8.4-xml \
+    php8.4-mbstring \
+    php8.4-memcached \
+    php8.4-opentelemetry
 RUN command -v php
 
 # Composer


### PR DESCRIPTION
### What does this PR do? How does it affect something?

Update ci image to support new version of php

todo-list
- [x] I expect the upcoming tag number to be `2.7`
- [x] update blemmyae/workflow files with new version [beforehand](https://github.com/cra-repo/blemmyae/pull/4274/changes/7ae2977e642822715cf859dbd66db16127103b38)
- [x] what to do with [this](https://github.com/cra-repo/cra-integrations/blob/master/docker/assets/Dockerfile#L1)?
- [x] release tag
- [x] build and publish the image
- [x] make sure if checking workflows in qa1 are working
  - [x] PHP Code Style / composer_validate (pull_request)
  - [x] PHP Code Style / phpstan (pull_request)

### YT issue and other related links
YT issues: 
- https://cra.myjetbrains.com/youtrack/issue/PORT-27773

Related PRs:
- https://github.com/cra-repo/blemmyae/pull/4274
- https://github.com/cra-repo/blemmyae/pull/4273
