### PR TITLE
PORT-27773 - Update instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,29 +32,29 @@ RUN apt-get install -y \
 RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
 
 # PHP
-RUN LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && apt-get update && apt-get install -y php8.2
+RUN LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && apt-get update && apt-get install -y php8.4
 RUN apt-get install -y \
-    php8.2-cli \
-    php8.2-fpm \
-    php8.2-curl \
-    php8.2-gd \
-    php8.2-dev \
-    php8.2-xml \
-    php8.2-bcmath \
-    php8.2-mysql \
-    php8.2-pgsql \
-    php8.2-zip \
-    php8.2-bz2 \
-    php8.2-sqlite \
-    php8.2-soap \
-    php8.2-intl \
-    php8.2-imap \
-    php8.2-imagick \
-    php8.2-amqp \
-    php8.2-xml \
-    php8.2-mbstring \
-    php8.2-memcached \
-    php8.2-opentelemetry
+    php8.4-cli \
+    php8.4-fpm \
+    php8.4-curl \
+    php8.4-gd \
+    php8.4-dev \
+    php8.4-xml \
+    php8.4-bcmath \
+    php8.4-mysql \
+    php8.4-pgsql \
+    php8.4-zip \
+    php8.4-bz2 \
+    php8.4-sqlite \
+    php8.4-soap \
+    php8.4-intl \
+    php8.4-imap \
+    php8.4-imagick \
+    php8.4-amqp \
+    php8.4-xml \
+    php8.4-mbstring \
+    php8.4-memcached \
+    php8.4-opentelemetry
 RUN command -v php
 
 # Composer

--- a/README.md
+++ b/README.md
@@ -5,14 +5,26 @@ Docker image for CI builds with PHP and Node.js.
 
 1. Create PR from a fork with changes.
 2. Merge PR and create a new tag on GitHub.
-3. Using the same tag name build and push image to DockerHub. Also, push the same image with `latest` tag to DockerHub.
+3. Request access to cyberriskalliance organization on DockerHub to your account from DevOps team. You need to have a DockerHub account. 
+4. Authenticate to docker cli.
+5. Using the same tag name build and push image to DockerHub. Also, push the same image with `latest` tag to DockerHub.
+
+To authenticate to docker cli run:
+```bash
+docker login -u your_login -p your_password
+```
 
 To build and publish the image run:
 
 ```bash
-docker build -t cyberriskalliance/ci-php-node:TAG_NAME -t cyberriskalliance/ci-php-node:latest .
-docker push cyberriskalliance/ci-php-node:TAG_NAME
-docker push cyberriskalliance/ci-php-node:latest
+docker buildx create --use --name multiarch-builder
+docker buildx build \
+  --platform linux/amd64 \
+  -t cyberriskalliance/ci-php-node:2.7 \
+  -t cyberriskalliance/ci-php-node:latest \
+  --push \
+  .
+
 ```
 
 # Credits


### PR DESCRIPTION
### What does this PR do? How does it affect something?

It updates `README.md`:
- more prerequisites regarding DockerHub access 
- edge case is considered. Apple Macbooks that have ARM processors installed are incompatible with x64 processors  running github runners. So we need to build x64-compatible-image explicitly.  
  - that is what I got by running old instructions with macbook pro m1 (ARM) on github workflows:
  ```bash
    /usr/bin/docker pull cyberriskalliance/ci-php-node:2.7
  no matching manifest for linux/amd64 in the manifest list entries
  2.7: Pulling from cyberriskalliance/ci-php-node
  ```
